### PR TITLE
adding Lazzate, corpnewbest and firmasegura strategies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osodreamer-sri-xml-signer",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osodreamer-sri-xml-signer",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.8",

--- a/src/sign-xml/infrastructure/certificate/factories/sign-strategy.factory.ts
+++ b/src/sign-xml/infrastructure/certificate/factories/sign-strategy.factory.ts
@@ -6,13 +6,19 @@ import {
   UanatacaStrategy,
 } from "../strategies";
 import { AnfacStrategy } from "../strategies/anfac.strategy";
+import { CorpnewbestStrategy } from "../strategies/corpnewbest.strategy";
+import { FirmaseguraStrategy } from "../strategies/firmasegura.strategy";
+import { LazzateStrategy } from "../strategies/lazzate.strategy";
 
 export class SignStrategyFactory {
   private readonly strategies: SignStrategy[] = [
     new BancoCentralStrategy(),
     new SecurityDataStrategy(),
     new UanatacaStrategy(),
-    new AnfacStrategy()
+    new AnfacStrategy(),
+    new CorpnewbestStrategy(),
+    new FirmaseguraStrategy(),
+    new LazzateStrategy(),
   ];
 
   getStrategy(friendlyName: string): SignStrategy {

--- a/src/sign-xml/infrastructure/certificate/strategies/corpnewbest.strategy.ts
+++ b/src/sign-xml/infrastructure/certificate/strategies/corpnewbest.strategy.ts
@@ -1,0 +1,37 @@
+import { getForge } from "../../../../utils/forge-loader";
+import { SignStrategy } from "../../interfaces";
+import {
+  PrivateKeyExtractionError,
+  SigningKeyNotFoundError,
+} from "../../errors";
+
+export class CorpnewbestStrategy implements SignStrategy {
+  supports(friendlyName: string): boolean {
+    return /CORPNEWBEST/i.test(friendlyName);
+  }
+
+  async getPrivateKey(
+    bags: any[]
+  ): Promise<any> {
+    const forge = await getForge();
+    const item = bags[0];
+    if (!item) throw new SigningKeyNotFoundError("CORPNEWBEST");
+    if (item?.key) {
+      return item.key;
+    } else if (item?.asn1) {
+      return forge.pki.privateKeyFromAsn1(item.asn1);
+    } else {
+      throw new PrivateKeyExtractionError();
+    }
+  }
+
+  async overrideIssuerName(certBags: any): Promise<string> {
+    const forge = await getForge();
+    const cert = certBags[forge.pki.oids.certBag][0].cert;
+    return cert.issuer.attributes
+      .slice()
+      .reverse()
+      .map((attr: any) => `${attr.shortName}=${attr.value}`)
+      .join(",");
+  }
+}

--- a/src/sign-xml/infrastructure/certificate/strategies/firmasegura.strategy.ts
+++ b/src/sign-xml/infrastructure/certificate/strategies/firmasegura.strategy.ts
@@ -1,0 +1,37 @@
+import { getForge } from "../../../../utils/forge-loader";
+import { SignStrategy } from "../../interfaces";
+import {
+  PrivateKeyExtractionError,
+  SigningKeyNotFoundError,
+} from "../../errors";
+
+export class FirmaseguraStrategy implements SignStrategy {
+  supports(friendlyName: string): boolean {
+    return /ENTIDAD DE CERTIFICACION DE INFORMACION/i.test(friendlyName);
+  }
+
+  async getPrivateKey(
+    bags: any[]
+  ): Promise<any> {
+    const forge = await getForge();
+    const item = bags[0];
+    if (!item) throw new SigningKeyNotFoundError("FIRMASEGURA");
+    if (item?.key) {
+      return item.key;
+    } else if (item?.asn1) {
+      return forge.pki.privateKeyFromAsn1(item.asn1);
+    } else {
+      throw new PrivateKeyExtractionError();
+    }
+  }
+
+  async overrideIssuerName(certBags: any): Promise<string> {
+    const forge = await getForge();
+    const cert = certBags[forge.pki.oids.certBag][0].cert;
+    return cert.issuer.attributes
+      .slice()
+      .reverse()
+      .map((attr: any) => `${attr.shortName}=${attr.value}`)
+      .join(",");
+  }
+}

--- a/src/sign-xml/infrastructure/certificate/strategies/index.ts
+++ b/src/sign-xml/infrastructure/certificate/strategies/index.ts
@@ -1,4 +1,7 @@
 export * from "./anfac.strategy";
 export * from "./banco-central.strategy";
+export * from "./corpnewbest.strategy";
+export * from "./firmasegura.strategy";
+export * from "./lazzate.strategy";
 export * from "./security-data.strategy";
 export * from "./uanataca.strategy";

--- a/src/sign-xml/infrastructure/certificate/strategies/lazzate.strategy.ts
+++ b/src/sign-xml/infrastructure/certificate/strategies/lazzate.strategy.ts
@@ -1,0 +1,37 @@
+import { getForge } from "../../../../utils/forge-loader";
+import { SignStrategy } from "../../interfaces";
+import {
+  PrivateKeyExtractionError,
+  SigningKeyNotFoundError,
+} from "../../errors";
+
+export class LazzateStrategy implements SignStrategy {
+  supports(friendlyName: string): boolean {
+    return /Lazzate/i.test(friendlyName);
+  }
+
+  async getPrivateKey(
+    bags: any[]
+  ): Promise<any> {
+    const forge = await getForge();
+    const item = bags[0];
+    if (!item) throw new SigningKeyNotFoundError("LAZZATE");
+    if (item?.key) {
+      return item.key;
+    } else if (item?.asn1) {
+      return forge.pki.privateKeyFromAsn1(item.asn1);
+    } else {
+      throw new PrivateKeyExtractionError();
+    }
+  }
+
+  async overrideIssuerName(certBags: any): Promise<string> {
+    const forge = await getForge();
+    const cert = certBags[forge.pki.oids.certBag][0].cert;
+    return cert.issuer.attributes
+      .slice()
+      .reverse()
+      .map((attr: any) => `${attr.shortName}=${attr.value}`)
+      .join(",");
+  }
+}


### PR DESCRIPTION
New strategies for: Lazzate, Corpnewbest and Firmasegura signature.

Had borrowed the p12/pfx file for each one of thoses sign a XML and sent it to SRi to test the changes. Also had tested with SecurityData to comprove it still work after my changes