### PR TITLE
feat: add firma-segura strategy

### DIFF
--- a/src/sign-xml/infrastructure/certificate/certificate-provider.implement.ts
+++ b/src/sign-xml/infrastructure/certificate/certificate-provider.implement.ts
@@ -26,9 +26,12 @@ export class CertificateProviderImplement implements CertificateProviderPort {
     const certBags = p12.getBags({ bagType: forge.pki.oids.certBag });
     const certificates = certBags[forge.oids.certBag];
 
+    //si no existe firendlyName, buscar attribute organizationName u O en el issuer del certificado
     const friendlyName =
       certificates?.[1]?.attributes?.friendlyName?.[0] ??
-      certificates?.[0]?.cert?.issuer?.attributes?.[2]?.value;
+      certificates?.[0]?.cert?.issuer?.attributes?.find(
+        (attr: any) => attr.name === "organizationName" || attr.shortName === "O"
+      )?.value;
 
     const strategy = this.strategyFactory.getStrategy(friendlyName);
     const privateKey = await strategy.getPrivateKey(

--- a/src/sign-xml/infrastructure/certificate/factories/sign-strategy.factory.ts
+++ b/src/sign-xml/infrastructure/certificate/factories/sign-strategy.factory.ts
@@ -6,13 +6,15 @@ import {
   UanatacaStrategy,
 } from "../strategies";
 import { AnfacStrategy } from "../strategies/anfac.strategy";
+import { FirmaSeguraStrategy } from "../strategies/firma-segura.strategy";
 
 export class SignStrategyFactory {
   private readonly strategies: SignStrategy[] = [
     new BancoCentralStrategy(),
     new SecurityDataStrategy(),
     new UanatacaStrategy(),
-    new AnfacStrategy()
+    new AnfacStrategy(),
+    new FirmaSeguraStrategy(),
   ];
 
   getStrategy(friendlyName: string): SignStrategy {

--- a/src/sign-xml/infrastructure/certificate/strategies/firma-segura.strategy.ts
+++ b/src/sign-xml/infrastructure/certificate/strategies/firma-segura.strategy.ts
@@ -1,0 +1,36 @@
+import { getForge } from "../../../../utils/forge-loader";
+import { SignStrategy } from "../../interfaces";
+import {
+  PrivateKeyExtractionError,
+  SigningKeyNotFoundError,
+} from "../../errors";
+
+export class FirmaSeguraStrategy implements SignStrategy {
+  supports(friendlyName: string): boolean {
+    return /FIRMASEGURA/i.test(friendlyName);
+  }
+
+  async getPrivateKey(
+    bags: any[]
+  ): Promise<any> {
+    const forge = await getForge();
+    const item = bags[0];
+    if (!item) throw new SigningKeyNotFoundError("FIRMASEGURA");
+    if (item?.key) {
+      return item.key;
+    } else if (item?.asn1) {
+      return forge.pki.privateKeyFromAsn1(item.asn1);
+    } else {
+      throw new PrivateKeyExtractionError();
+    }
+  }
+
+  async overrideIssuerName(certBags: any): Promise<string> {
+    const forge = await getForge();
+    const cert = certBags[forge.pki.oids.certBag][0].cert;
+    return cert.issuer.attributes
+      .reverse()
+      .map((attr: any) => `${attr.shortName}=${attr.value}`)
+      .join(",");
+  }
+}


### PR DESCRIPTION
## Description
Adds firma-segura strategy to accept digital signatures coming with that vendor

## Changes
-Adds new firma-segura.strategy.ts file
-Searches for attribute name = organizartionName instead of getting from the array position